### PR TITLE
12 add alphastr and maybe alphastring

### DIFF
--- a/src/clib/trie.rs
+++ b/src/clib/trie.rs
@@ -3,6 +3,7 @@ use datrie::{
     alpha_map::AlphaMap,
     fileutils::CFile,
     trie::{Trie, TrieData, TrieEnumFunc, TrieIterator, TrieState},
+    AlphaStr,
 };
 use std::{ffi::CStr, ptr};
 
@@ -122,7 +123,8 @@ pub unsafe extern "C" fn trie_retrieve(
         return DA_FALSE;
     }
     let trie = unsafe { &*trie };
-    trie.retrieve(key, o_data)
+    let alpha_key = AlphaStr::from_ptr(key);
+    trie.retrieve(&alpha_key, o_data)
 }
 #[no_mangle]
 pub unsafe extern "C" fn trie_store(
@@ -134,6 +136,7 @@ pub unsafe extern "C" fn trie_store(
         return DA_FALSE;
     }
     let trie = unsafe { &mut *trie };
+    let alpha_key = AlphaStr::from_ptr(key);
     trie.store(key, data)
 }
 #[no_mangle]
@@ -146,6 +149,7 @@ pub unsafe extern "C" fn trie_store_if_absent(
         return DA_FALSE;
     }
     let trie = unsafe { &mut *trie };
+    let alpha_key = AlphaStr::from_ptr(key);
     trie.store(key, data)
 }
 #[no_mangle]
@@ -154,6 +158,7 @@ pub unsafe extern "C" fn trie_delete(trie: *mut Trie, key: *const AlphaChar) -> 
         return DA_FALSE;
     }
     let trie = unsafe { &mut *trie };
+    let alpha_key = AlphaStr::from_ptr(key);
     trie.delete(key)
 }
 #[no_mangle]

--- a/src/clib/trie.rs
+++ b/src/clib/trie.rs
@@ -137,7 +137,7 @@ pub unsafe extern "C" fn trie_store(
     }
     let trie = unsafe { &mut *trie };
     let alpha_key = AlphaStr::from_ptr(key);
-    trie.store(key, data)
+    trie.store(&alpha_key, data)
 }
 #[no_mangle]
 pub unsafe extern "C" fn trie_store_if_absent(
@@ -150,7 +150,7 @@ pub unsafe extern "C" fn trie_store_if_absent(
     }
     let trie = unsafe { &mut *trie };
     let alpha_key = AlphaStr::from_ptr(key);
-    trie.store(key, data)
+    trie.store(&alpha_key, data)
 }
 #[no_mangle]
 pub unsafe extern "C" fn trie_delete(trie: *mut Trie, key: *const AlphaChar) -> Bool {

--- a/src/clib/trie.rs
+++ b/src/clib/trie.rs
@@ -159,7 +159,7 @@ pub unsafe extern "C" fn trie_delete(trie: *mut Trie, key: *const AlphaChar) -> 
     }
     let trie = unsafe { &mut *trie };
     let alpha_key = AlphaStr::from_ptr(key);
-    trie.delete(key)
+    trie.delete(&alpha_key)
 }
 #[no_mangle]
 pub unsafe extern "C" fn trie_enumerate(

--- a/src/lib/alpha_str.rs
+++ b/src/lib/alpha_str.rs
@@ -1,0 +1,535 @@
+use core::{fmt, ops, slice};
+use std::error::Error;
+use std::ptr::addr_of;
+
+use crate::alpha_map::AlphaChar;
+
+#[derive(PartialEq, Eq, Hash, Debug)]
+// `fn from` in `impl From<&AlphaStr> for Box<AlphaStr>` current implementation relies
+// on `AlphaStr` being layout-compatible with `[AlphaChar]`.
+// However, `AlphaStr` layout is considered an implementation detail and must not be relied upon. We
+// want `repr(transparent)` but we don't want it to show up in rustdoc, so we hide it under
+// `cfg(doc)`. This is an ad-hoc implementation of attribute privacy.
+#[repr(transparent)]
+pub struct AlphaStr {
+    // FIXME: this should not be represented with a DST slice but rather with
+    //        just a raw `AlphaChar` along with some form of marker to make
+    //        this an unsized type. Essentially `sizeof(&AlphaStr)` should be the
+    //        same as `sizeof(&AlphaChar)` but `AlphaStr` should be an unsized type.
+    inner: [AlphaChar],
+}
+
+/// An error indicating that a nul byte was not in the expected position.
+///
+/// The slice used to create a [`AlphaStr`] must have one and only one nul byte,
+/// positioned at the end.
+///
+/// This error is created by the [`AlphaStr::from_slice_with_nul`] method.
+/// See its documentation for more.
+///
+/// # Examples
+///
+/// ```
+/// use datrie::alpha_str::{AlphaStr, FromSliceWithNulError};
+///
+/// let _: FromSliceWithNulError = AlphaStr::from_slice_with_nul(&['f' as u32, 0, 'o' as u32, 'o' as u32]).unwrap_err();
+/// ```
+#[derive(Clone, PartialEq, Eq, Debug)]
+pub struct FromSliceWithNulError {
+    kind: FromSliceWithNulErrorKind,
+}
+
+#[derive(Clone, PartialEq, Eq, Debug)]
+enum FromSliceWithNulErrorKind {
+    InteriorNul(usize),
+    NotNulTerminated,
+}
+
+// FIXME: const stability attributes should not be required here, I think
+impl FromSliceWithNulError {
+    const fn interior_nul(pos: usize) -> FromSliceWithNulError {
+        FromSliceWithNulError {
+            kind: FromSliceWithNulErrorKind::InteriorNul(pos),
+        }
+    }
+
+    const fn not_nul_terminated() -> FromSliceWithNulError {
+        FromSliceWithNulError {
+            kind: FromSliceWithNulErrorKind::NotNulTerminated,
+        }
+    }
+}
+
+impl Error for FromSliceWithNulError {
+    #[allow(deprecated)]
+    fn description(&self) -> &str {
+        match self.kind {
+            FromSliceWithNulErrorKind::InteriorNul(..) => {
+                "data provided contains an interior nul byte"
+            }
+            FromSliceWithNulErrorKind::NotNulTerminated => "data provided is not nul terminated",
+        }
+    }
+}
+
+/// An error indicating that no nul byte was present.
+///
+/// A slice used to create a [`AlphaStr`] must contain a nul byte somewhere
+/// within the slice.
+///
+/// This error is created by the [`AlphaStr::from_slice_until_nul`] method.
+///
+#[derive(Clone, PartialEq, Eq, Debug)]
+pub struct FromSliceUntilNulError(());
+
+impl fmt::Display for FromSliceUntilNulError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "data provided does not contain a nul")
+    }
+}
+
+// impl fmt::Debug for AlphaStr {
+//     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+//         write!(f, "\"{:?}\"", self.to_slice().iter().map(|c| c as char))
+//     }
+// }
+
+impl Default for &AlphaStr {
+    #[inline]
+    fn default() -> Self {
+        const SLICE: &[AlphaChar] = &[0];
+        // SAFETY: `SLICE` is indeed pointing to a valid nul-terminated string.
+        unsafe { AlphaStr::from_ptr(SLICE.as_ptr()) }
+    }
+}
+
+impl fmt::Display for FromSliceWithNulError {
+    #[allow(deprecated, deprecated_in_future)]
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.description())?;
+        if let FromSliceWithNulErrorKind::InteriorNul(pos) = self.kind {
+            write!(f, " at byte pos {pos}")?;
+        }
+        Ok(())
+    }
+}
+
+impl AlphaStr {
+    /// Wraps a raw C string with a safe C string wrapper.
+    ///
+    /// This function will wrap the provided `ptr` with a `AlphaStr` wrapper, which
+    /// allows inspection and interoperation of non-owned C strings. The total
+    /// size of the terminated buffer must be smaller than [`isize::MAX`] **bytes**
+    /// in memory (a restriction from [`slice::from_raw_parts`]).
+    ///
+    /// # Safety
+    ///
+    /// * The memory pointed to by `ptr` must contain a valid nul terminator at the
+    ///   end of the string.
+    ///
+    /// * `ptr` must be [valid] for reads of bytes up to and including the nul terminator.
+    ///   This means in particular:
+    ///
+    ///     * The entire memory range of this `AlphaStr` must be contained within a single allocated object!
+    ///     * `ptr` must be non-null even for a zero-length cstr.
+    ///
+    /// * The memory referenced by the returned `AlphaStr` must not be mutated for
+    ///   the duration of lifetime `'a`.
+    ///
+    /// * The nul terminator must be within `isize::MAX` from `ptr`
+    ///
+    /// > **Note**: This operation is intended to be a 0-cost cast but it is
+    /// > currently implemented with an up-front calculation of the length of
+    /// > the string. This is not guaranteed to always be the case.
+    ///
+    /// # Caveat
+    ///
+    /// The lifetime for the returned slice is inferred from its usage. To prevent accidental misuse,
+    /// it's suggested to tie the lifetime to whichever source lifetime is safe in the context,
+    /// such as by providing a helper function taking the lifetime of a host value for the slice,
+    /// or by explicit annotation.
+    ///
+    /// # Examples
+    ///
+    ///
+    /// ```
+    /// use datrie::alpha_str::AlphaStr;
+    /// use datrie::alpha_map::AlphaChar;
+    ///
+    /// // const HELLO_PTR: *const AlphaChar = {
+    /// //    const BYTES: &[AlphaChar] = b"Hello, world!\0";
+    /// //    BYTES.as_ptr().cast()
+    /// // };
+    /// // const HELLO: &AlphaStr = unsafe { AlphaStr::from_ptr(HELLO_PTR) };
+    ///
+    /// // assert_eq!(c"Hello, world!", HELLO);
+    /// ```
+    ///
+    /// [valid]: core::ptr#safety
+    #[inline] // inline is necessary for codegen to see strlen.
+    #[must_use]
+    pub unsafe fn from_ptr<'a>(ptr: *const AlphaChar) -> &'a AlphaStr {
+        // SAFETY: The caller has provided a pointer that points to a valid C
+        // string with a NUL terminator less than `isize::MAX` from `ptr`.
+        let len = unsafe { alpha_char_strlen(ptr) };
+
+        // SAFETY: The caller has provided a valid pointer with length less than
+        // `isize::MAX`, so `from_raw_parts` is safe. The content remains valid
+        // and doesn't change for the lifetime of the returned `AlphaStr`. This
+        // means the call to `from_slice_with_nul_unchecked` is correct.
+        //
+        // The cast from AlphaChar to AlphaChar is ok because a AlphaChar is always one byte.
+        unsafe { Self::from_slice_with_nul_unchecked(slice::from_raw_parts(ptr.cast(), len + 1)) }
+    }
+
+    /// Creates a C string wrapper from a byte slice with any number of nuls.
+    ///
+    /// This method will create a `AlphaStr` from any byte slice that contains at
+    /// least one nul byte. Unlike with [`AlphaStr::from_slice_with_nul`], the caller
+    /// does not need to know where the nul byte is located.
+    ///
+    /// If the first byte is a nul character, this method will return an
+    /// empty `AlphaStr`. If multiple nul characters are present, the `AlphaStr` will
+    /// end at the first one.
+    ///
+    /// If the slice only has a single nul byte at the end, this method is
+    /// equivalent to [`AlphaStr::from_slice_with_nul`].
+    ///
+    /// # Examples
+    /// ```
+    /// use datrie::AlphaStr;
+    ///
+    /// let mut buffer = [0 as u32; 16];
+    /// unsafe {
+    ///     // Here we might call an unsafe C function that writes a string
+    ///     // into the buffer.
+    ///     let mut buf_ptr = buffer.as_mut_ptr();
+    ///     for _ in 0..8 {
+    ///         *buf_ptr = 'A' as u32;
+    ///         buf_ptr = buf_ptr.offset(1);
+    ///     }
+    /// }
+    /// // Attempt to extract a C nul-terminated string from the buffer.
+    /// let c_str = AlphaStr::from_slice_until_nul(&buffer[..]).unwrap();
+    /// assert_eq!(c_str.to_slice(), &['A' as u32, 'A' as u32, 'A' as u32, 'A' as u32, 'A' as u32, 'A' as u32, 'A' as u32, 'A' as u32]);
+    /// ```
+    ///
+    pub fn from_slice_until_nul(bytes: &[AlphaChar]) -> Result<&AlphaStr, FromSliceUntilNulError> {
+        // let mut buffer = [0 as u32; 16];
+        // unsafe {
+        //     let buf_ptr = buffer.as_mut_ptr();
+        //     buf_ptr.write_s
+        // }
+        let nul_pos = alpha_char_memchr(0, bytes);
+        match nul_pos {
+            Some(nul_pos) => {
+                // FIXME(const-hack) replace with range index
+                // SAFETY: nul_pos + 1 <= bytes.len()
+                let subslice = unsafe { slice::from_raw_parts(bytes.as_ptr(), nul_pos + 1) };
+                // SAFETY: We know there is a nul byte at nul_pos, so this slice
+                // (ending at the nul byte) is a well-formed C string.
+                Ok(unsafe { AlphaStr::from_slice_with_nul_unchecked(subslice) })
+            }
+            None => Err(FromSliceUntilNulError(())),
+        }
+    }
+
+    /// Creates a C string wrapper from a byte slice with exactly one nul
+    /// terminator.
+    ///
+    /// This function will cast the provided `bytes` to a `AlphaStr`
+    /// wrapper after ensuring that the byte slice is nul-terminated
+    /// and does not contain any interior nul bytes.
+    ///
+    /// If the nul byte may not be at the end,
+    /// [`AlphaStr::from_slice_until_nul`] can be used instead.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use datrie::AlphaStr;
+    ///
+    /// let cstr = AlphaStr::from_slice_with_nul(&['h' as u32, 'e' as u32, 'l' as u32, 'l' as u32, 'o' as u32,0]);
+    /// assert!(cstr.is_ok());
+    /// ```
+    ///
+    /// Creating a `AlphaStr` without a trailing nul terminator is an error:
+    ///
+    /// ```
+    /// use datrie::AlphaStr;
+    ///
+    /// let cstr = AlphaStr::from_slice_with_nul(&['h' as u32, 'e' as u32, 'l' as u32, 'l' as u32, 'o' as u32]);
+    /// assert!(cstr.is_err());
+    /// ```
+    ///
+    /// Creating a `AlphaStr` with an interior nul byte is an error:
+    ///
+    /// ```
+    /// use datrie::AlphaStr;
+    ///
+    /// let cstr = AlphaStr::from_slice_with_nul(&['h' as u32, 'e' as u32, 0, 'l' as u32, 'l' as u32, 'o' as u32]);
+    /// assert!(cstr.is_err());
+    /// ```
+    pub fn from_slice_with_nul(bytes: &[AlphaChar]) -> Result<&Self, FromSliceWithNulError> {
+        let nul_pos = alpha_char_memchr(0, bytes);
+        match nul_pos {
+            Some(nul_pos) if nul_pos + 1 == bytes.len() => {
+                // SAFETY: We know there is only one nul byte, at the end
+                // of the byte slice.
+                Ok(unsafe { Self::from_slice_with_nul_unchecked(bytes) })
+            }
+            Some(nul_pos) => Err(FromSliceWithNulError::interior_nul(nul_pos)),
+            None => Err(FromSliceWithNulError::not_nul_terminated()),
+        }
+    }
+
+    /// Unsafely creates a C string wrapper from a byte slice.
+    ///
+    /// This function will cast the provided `bytes` to a `AlphaStr` wrapper without
+    /// performing any sanity checks.
+    ///
+    /// # Safety
+    /// The provided slice **must** be nul-terminated and not contain any interior
+    /// nul bytes.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use datrie::alpha_str::AlphaStr;
+    ///
+    /// unsafe {
+    ///     let alpha_slice = &['f' as u32, 'o' as u32, 'o' as u32, 0];
+    ///     let cstr = AlphaStr::from_slice_with_nul_unchecked(alpha_slice);
+    ///     assert_eq!(cstr.to_slice_with_nul(), alpha_slice);
+    /// }
+    /// ```
+    #[inline]
+    #[must_use]
+    pub unsafe fn from_slice_with_nul_unchecked(bytes: &[AlphaChar]) -> &AlphaStr {
+        // Chance at catching some UB at runtime with debug builds.
+        debug_assert!(!bytes.is_empty() && bytes[bytes.len() - 1] == 0);
+
+        // SAFETY: Casting to AlphaStr is safe because its internal representation
+        // is a [AlphaChar] too (safe only inside std).
+        // Dereferencing the obtained pointer is safe because it comes from a
+        // reference. Making a reference is then safe because its lifetime
+        // is bound by the lifetime of the given `bytes`.
+        unsafe { &*(bytes as *const [AlphaChar] as *const AlphaStr) }
+    }
+
+    /// Returns the inner pointer to this C string.
+    ///
+    /// The returned pointer will be valid for as long as `self` is, and points
+    /// to a contiguous region of memory terminated with a 0 byte to represent
+    /// the end of the string.
+    ///
+    /// The type of the returned pointer is
+    /// [`*const AlphaChar`][crate::ffi::AlphaChar], and whether it's
+    /// an alias for `*const i8` or `*const AlphaChar` is platform-specific.
+    ///
+    /// **WARNING**
+    ///
+    /// The returned pointer is read-only; writing to it (including passing it
+    /// to C code that writes to it) causes undefined behavior.
+    ///
+    /// It is your responsibility to make sure that the underlying memory is not
+    /// freed too early. For example, the following code will cause undefined
+    /// behavior when `ptr` is used inside the `unsafe` block:
+    ///
+    /// ```no_run
+    /// # #![allow(unused_must_use)]
+    /// // use datrie::AlphaString;
+    ///
+    /// // Do not do this:
+    /// // let ptr = AlphaString::new("Hello").expect("AlphaString::new failed").as_ptr();
+    /// unsafe {
+    ///     // `ptr` is dangling
+    ///     //*ptr;
+    /// }
+    /// ```
+    ///
+    /// This happens because the pointer returned by `as_ptr` does not carry any
+    /// lifetime information and the `AlphaString` is deallocated immediately after
+    /// the `AlphaString::new("Hello").expect("AlphaString::new failed").as_ptr()`
+    /// expression is evaluated.
+    /// To fix the problem, bind the `AlphaString` to a local variable:
+    ///
+    /// ```no_run
+    /// # #![allow(unused_must_use)]
+    /// //use datrie::AlphaString;
+    ///
+    /// //let hello = AlphaStr::new("Hello").expect("AlphaString::new failed");
+    /// //let ptr = hello.as_ptr();
+    /// unsafe {
+    ///     // `ptr` is valid because `hello` is in scope
+    ///     //*ptr;
+    /// }
+    /// ```
+    ///
+    /// This way, the lifetime of the `AlphaString` in `hello` encompasses
+    /// the lifetime of `ptr` and the `unsafe` block.
+    #[inline]
+    #[must_use]
+    pub const fn as_ptr(&self) -> *const AlphaChar {
+        self.inner.as_ptr()
+    }
+
+    /// We could eventually expose this publicly, if we wanted.
+    // #[inline]
+    // #[must_use]
+    // const fn as_non_null_ptr(&self) -> NonNull<AlphaChar> {
+    //     // FIXME(const_trait_impl) replace with `NonNull::from`
+    //     // SAFETY: a reference is never null
+    //     unsafe { NonNull::new_unchecked(&self.inner as *const [AlphaChar] as *mut [AlphaChar]) }
+    //         .as_non_null_ptr()
+    // }
+
+    /// Returns the length of `self`. Like C's `strlen`, this does not include the nul terminator.
+    ///
+    /// > **Note**: This method is currently implemented as a constant-time
+    /// > cast, but it is planned to alter its definition in the future to
+    /// > perform the length calculation whenever this method is called.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use datrie::AlphaStr;
+    ///
+    /// let cstr = AlphaStr::from_slice_with_nul(&['f' as u32, 'o' as u32, 'o' as u32, 0]).unwrap();
+    /// assert_eq!(cstr.count_slice(), 3);
+    ///
+    /// let cstr = AlphaStr::from_slice_with_nul(&[0]).unwrap();
+    /// assert_eq!(cstr.count_slice(), 0);
+    /// ```
+    #[inline]
+    #[must_use]
+    #[doc(alias("len", "strlen"))]
+    pub const fn count_slice(&self) -> usize {
+        self.inner.len() - 1
+    }
+
+    /// Returns `true` if `self.to_slice()` has a length of 0.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use datrie::alpha_str::AlphaStr;
+    /// # use datrie::alpha_str::FromSliceWithNulError;
+    ///
+    /// # fn main() { test().unwrap(); }
+    /// # fn test() -> Result<(), FromSliceWithNulError> {
+    /// let cstr = AlphaStr::from_slice_with_nul(&['f' as u32, 'o' as u32, 'o' as u32, 0])?;
+    /// assert!(!cstr.is_empty());
+    ///
+    /// let empty_cstr = AlphaStr::from_slice_with_nul(&[0])?;
+    /// assert!(empty_cstr.is_empty());
+    /// assert!(c"".is_empty());
+    /// # Ok(())
+    /// # }
+    /// ```
+    #[inline]
+    pub const fn is_empty(&self) -> bool {
+        // SAFETY: We know there is at least one byte; for empty strings it
+        // is the NUL terminator.
+        // FIXME(const-hack): use get_unchecked
+        unsafe { *self.inner.as_ptr() == 0 }
+    }
+
+    /// Converts this C string to a byte slice.
+    ///
+    /// The returned slice will **not** contain the trailing nul terminator that this C
+    /// string has.
+    ///
+    /// > **Note**: This method is currently implemented as a constant-time
+    /// > cast, but it is planned to alter its definition in the future to
+    /// > perform the length calculation whenever this method is called.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use datrie::AlphaStr;
+    ///
+    /// let cstr = AlphaStr::from_slice_with_nul(&['f' as u32, 'o' as u32, 'o' as u32, 0]).expect("AlphaStr::from_slice_with_nul failed");
+    /// assert_eq!(cstr.to_slice(), &['f' as u32, 'o' as u32, 'o' as u32]);
+    /// ```
+    #[inline]
+    #[must_use = "this returns the result of the operation, \
+                  without modifying the original"]
+    pub const fn to_slice(&self) -> &[AlphaChar] {
+        let bytes = self.to_slice_with_nul();
+        // FIXME(const-hack) replace with range index
+        // SAFETY: to_slice_with_nul returns slice with length at least 1
+        unsafe { slice::from_raw_parts(bytes.as_ptr(), bytes.len() - 1) }
+    }
+
+    /// Converts this C string to a byte slice containing the trailing 0 byte.
+    ///
+    /// This function is the equivalent of [`AlphaStr::to_slice`] except that it
+    /// will retain the trailing nul terminator instead of chopping it off.
+    ///
+    /// > **Note**: This method is currently implemented as a 0-cost cast, but
+    /// > it is planned to alter its definition in the future to perform the
+    /// > length calculation whenever this method is called.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use datrie::AlphaStr;
+    ///
+    /// let cstr = AlphaStr::from_slice_with_nul(&['f' as u32, 'o' as u32, 'o' as u32, 0]).expect("AlphaStr::from_slice_with_nul failed");
+    /// assert_eq!(cstr.to_slice_with_nul(), &['f' as u32, 'o' as u32, 'o' as u32,0]);
+    /// ```
+    #[inline]
+    #[must_use = "this returns the result of the operation, \
+                  without modifying the original"]
+    pub const fn to_slice_with_nul(&self) -> &[AlphaChar] {
+        // SAFETY: Transmuting a slice of `AlphaChar`s to a slice of `AlphaChar`s
+        // is safe on all supported targets.
+        unsafe { &*((addr_of!(self.inner)) as *const [AlphaChar]) }
+    }
+}
+
+impl ops::Index<ops::RangeFrom<usize>> for AlphaStr {
+    type Output = AlphaStr;
+
+    #[inline]
+    fn index(&self, index: ops::RangeFrom<usize>) -> &AlphaStr {
+        let bytes = self.to_slice_with_nul();
+        // we need to manually check the starting index to account for the null
+        // byte, since otherwise we could get an empty string that doesn't end
+        // in a null.
+        if index.start < bytes.len() {
+            // SAFETY: Non-empty tail of a valid `AlphaStr` is still a valid `AlphaStr`.
+            unsafe { AlphaStr::from_slice_with_nul_unchecked(&bytes[index.start..]) }
+        } else {
+            panic!(
+                "index out of bounds: the len is {} but the index is {}",
+                bytes.len(),
+                index.start
+            );
+        }
+    }
+}
+
+impl AsRef<AlphaStr> for AlphaStr {
+    #[inline]
+    fn as_ref(&self) -> &AlphaStr {
+        self
+    }
+}
+
+fn alpha_char_memchr(needle: AlphaChar, haystack: &[AlphaChar]) -> Option<usize> {
+    for (idx, hay) in haystack.iter().enumerate() {
+        if *hay == needle {
+            return Some(idx);
+        }
+    }
+    None
+}
+pub unsafe fn alpha_char_strlen(str: *const AlphaChar) -> usize {
+    let mut p: *const AlphaChar = str;
+    while *p != 0 {
+        p = p.offset(1);
+    }
+    p.offset_from(str) as usize
+}

--- a/src/lib/lib.rs
+++ b/src/lib/lib.rs
@@ -15,8 +15,10 @@ pub mod fileutils;
 pub mod tail;
 pub mod trie;
 // pub mod trie_char_string;
+pub mod alpha_str;
 pub mod trie_string;
 
+pub use crate::alpha_str::AlphaStr;
 pub use crate::error::{DatrieError, ErrorKind};
 
 pub type DatrieResult<T> = Result<T, DatrieError>;

--- a/src/lib/tests/api/test_byte_alpha.rs
+++ b/src/lib/tests/api/test_byte_alpha.rs
@@ -26,7 +26,7 @@
 use datrie::{
     alpha_map::AlphaMap,
     trie::{Trie, TrieData, DA_TRUE},
-    DatrieResult,
+    AlphaStr, DatrieResult,
 };
 
 use crate::utils::msg_step;
@@ -47,7 +47,7 @@ fn test_byte_alpha() -> DatrieResult<()> {
         let mut test_trie = Trie::new(&alpha_map)?;
 
         msg_step("Storing key to test trie");
-        let key = &[0xff, 0xff, 0];
+        let key = AlphaStr::from_slice_with_nul(&[0xff, 0xff, 0]).unwrap();
         assert_eq!(
             Trie::store(&mut test_trie, key.as_ptr(), TEST_DATA),
             DA_TRUE,
@@ -57,7 +57,7 @@ fn test_byte_alpha() -> DatrieResult<()> {
         msg_step("Retrieving data from test trie");
         let mut data = 0;
         assert_eq!(
-            Trie::retrieve(&test_trie, key.as_ptr(), &mut data),
+            Trie::retrieve(&test_trie, key, &mut data),
             DA_TRUE,
             "Fail to retrieve key from test trie\n"
         );

--- a/src/lib/tests/api/test_byte_alpha.rs
+++ b/src/lib/tests/api/test_byte_alpha.rs
@@ -49,7 +49,7 @@ fn test_byte_alpha() -> DatrieResult<()> {
         msg_step("Storing key to test trie");
         let key = AlphaStr::from_slice_with_nul(&[0xff, 0xff, 0]).unwrap();
         assert_eq!(
-            Trie::store(&mut test_trie, key.as_ptr(), TEST_DATA),
+            Trie::store(&mut test_trie, key, TEST_DATA),
             DA_TRUE,
             "Fail to store key to test trie\n"
         );

--- a/src/lib/tests/api/test_byte_list.rs
+++ b/src/lib/tests/api/test_byte_list.rs
@@ -32,24 +32,32 @@ extern "C" {
 
 #[derive(Debug, Clone, Copy)]
 struct DictEntry {
-    key: [AlphaChar; 4],
+    key: &'static AlphaStr,
     data: TrieData,
     is_checked: bool,
 }
 
 // /* Dictionary source */
-const SOURCE: [DictEntry; 2] = [
-    DictEntry {
-        key: ['1' as AlphaChar, '2' as AlphaChar, 0, 0],
-        data: 1,
-        is_checked: false,
-    },
-    DictEntry {
-        key: ['1' as AlphaChar, '2' as AlphaChar, '3' as AlphaChar, 0],
-        data: 2,
-        is_checked: false,
-    },
-];
+fn get_source() -> [DictEntry; 2] {
+    [
+        DictEntry {
+            key: &AlphaStr::from_slice_with_nul(&['1' as AlphaChar, '2' as AlphaChar, 0]).unwrap(),
+            data: 1,
+            is_checked: false,
+        },
+        DictEntry {
+            key: &AlphaStr::from_slice_with_nul(&[
+                '1' as AlphaChar,
+                '2' as AlphaChar,
+                '3' as AlphaChar,
+                0,
+            ])
+            .unwrap(),
+            data: 2,
+            is_checked: false,
+        },
+    ]
+}
 
 unsafe fn dump_key_data(key: *const AlphaChar, data: TrieData) {
     print!("[");
@@ -112,7 +120,7 @@ fn is_all_checked(source: &[DictEntry]) -> bool {
 use datrie::{
     alpha_map::{alpha_char_strcmp, AlphaChar, AlphaMap},
     trie::{Trie, TrieData, TrieIterator, TrieState, DA_FALSE},
-    DatrieResult,
+    AlphaStr, DatrieResult,
 };
 
 use crate::utils::msg_step;
@@ -131,9 +139,9 @@ fn test_byte_list() -> DatrieResult<()> {
         let mut test_trie = Trie::new(&alpha_map)?;
 
         msg_step("Storing entries to test trie");
-        let mut source = SOURCE;
+        let mut source = get_source();
         for dict_p in &source {
-            if Trie::store(&mut test_trie, dict_p.key.as_ptr(), dict_p.data) == 0 {
+            if Trie::store(&mut test_trie, dict_p.key, dict_p.data) == 0 {
                 panic!(
                     "Fail to store entry to test trie: {:?}->{}",
                     dict_p.key, dict_p.data

--- a/src/lib/tests/api/test_file.rs
+++ b/src/lib/tests/api/test_file.rs
@@ -83,7 +83,7 @@ fn test_file() -> DatrieResult<()> {
         let mut dict_src = get_dict_src();
         for dict_p in &dict_src {
             assert_eq!(
-                Trie::store(&mut test_trie, dict_p.key.as_ptr(), dict_p.data),
+                Trie::store(&mut test_trie, dict_p.key, dict_p.data),
                 DA_TRUE,
                 "Failed to add key '{:?}', data {}.\n",
                 dict_p.key,
@@ -154,7 +154,7 @@ fn test_save_file_and_reload() -> DatrieResult<()> {
     for dict_p in &dict_src {
         unsafe {
             assert_eq!(
-                Trie::store(&mut test_trie, dict_p.key.as_ptr(), dict_p.data),
+                Trie::store(&mut test_trie, dict_p.key, dict_p.data),
                 DA_TRUE,
                 "Failed to add key '{:?}', data {}.\n",
                 dict_p.key,

--- a/src/lib/tests/api/test_iterator.rs
+++ b/src/lib/tests/api/test_iterator.rs
@@ -48,7 +48,7 @@ fn test_iterator() -> DatrieResult<()> {
         let mut dict_src = get_dict_src();
         for dict_p in &dict_src {
             assert_eq!(
-                Trie::store(&mut test_trie, dict_p.key.as_ptr(), dict_p.data),
+                Trie::store(&mut test_trie, dict_p.key, dict_p.data),
                 DA_TRUE,
                 "Failed to add key '{:?}', data {}.\n",
                 dict_p.key,

--- a/src/lib/tests/api/test_nonalpha.rs
+++ b/src/lib/tests/api/test_nonalpha.rs
@@ -24,7 +24,7 @@
 use datrie::{
     alpha_map::AlphaChar,
     trie::{Trie, DA_TRUE},
-    DatrieResult,
+    AlphaStr, DatrieResult,
 };
 
 use crate::utils::{en_trie_new, get_dict_src, msg_step, TRIE_DATA_UNREAD};
@@ -50,7 +50,7 @@ fn test_nonalpha() -> DatrieResult<()> {
 
         //     /* test storing keys with non-alphabet chars */
         let nonalpha_src = [
-            &[
+            &AlphaStr::from_slice_with_nul(&[
                 'a' as AlphaChar,
                 '6' as AlphaChar,
                 'a' as AlphaChar,
@@ -58,8 +58,9 @@ fn test_nonalpha() -> DatrieResult<()> {
                 'u' as AlphaChar,
                 's' as AlphaChar,
                 0x0000,
-            ],
-            &[
+            ])
+            .unwrap(),
+            &AlphaStr::from_slice_with_nul(&[
                 'a' as AlphaChar,
                 '5' as AlphaChar,
                 'a' as AlphaChar,
@@ -67,13 +68,14 @@ fn test_nonalpha() -> DatrieResult<()> {
                 'u' as AlphaChar,
                 's' as AlphaChar,
                 0x0000,
-            ],
+            ])
+            .unwrap(),
         ];
 
         let mut trie_data = 0;
         for nonalpha_key in nonalpha_src {
             assert_ne!(
-                Trie::retrieve(&test_trie, nonalpha_key.as_ptr(), &mut trie_data),
+                Trie::retrieve(&test_trie, nonalpha_key, &mut trie_data),
                 DA_TRUE,
                 "False duplication on key '{:?}', with existing data {}.\n",
                 nonalpha_key,

--- a/src/lib/tests/api/test_nonalpha.rs
+++ b/src/lib/tests/api/test_nonalpha.rs
@@ -40,7 +40,7 @@ fn test_nonalpha() -> DatrieResult<()> {
         let dict_src = get_dict_src();
         for dict_p in &dict_src {
             assert_eq!(
-                Trie::store(&mut test_trie, dict_p.key.as_ptr(), dict_p.data),
+                Trie::store(&mut test_trie, dict_p.key, dict_p.data),
                 DA_TRUE,
                 "Failed to add key '{:?}', data {}.\n",
                 dict_p.key,
@@ -82,7 +82,7 @@ fn test_nonalpha() -> DatrieResult<()> {
                 trie_data
             );
             assert_ne!(
-                Trie::store(&mut test_trie, nonalpha_key.as_ptr(), TRIE_DATA_UNREAD),
+                Trie::store(&mut test_trie, nonalpha_key, TRIE_DATA_UNREAD),
                 DA_TRUE,
                 "Wrongly added key '{:?}' containing non-alphanet char\n",
                 nonalpha_key

--- a/src/lib/tests/api/test_serialization.rs
+++ b/src/lib/tests/api/test_serialization.rs
@@ -43,7 +43,7 @@ fn test_serialization() -> DatrieResult<()> {
     unsafe {
         for dict_p in &dict_src {
             assert_eq!(
-                Trie::store(&mut test_trie, dict_p.key.as_ptr(), dict_p.data),
+                Trie::store(&mut test_trie, dict_p.key, dict_p.data),
                 DA_TRUE,
                 "Failed to add key '{:?}', data {}.\n",
                 dict_p.key,
@@ -107,7 +107,7 @@ fn test_serialization_safe() -> DatrieResult<()> {
     for dict_p in &dict_src {
         unsafe {
             assert_eq!(
-                Trie::store(&mut test_trie, dict_p.key.as_ptr(), dict_p.data),
+                Trie::store(&mut test_trie, dict_p.key, dict_p.data),
                 DA_TRUE,
                 "Failed to add key '{:?}', data {}.\n",
                 dict_p.key,

--- a/src/lib/tests/api/test_store_retrieve.rs
+++ b/src/lib/tests/api/test_store_retrieve.rs
@@ -105,7 +105,7 @@ fn test_store_retrieve() {
                 }
             }
             println!("Deleting '{:?}'", dict_src[i].key);
-            if Trie::delete(&mut test_trie, dict_src[i].key.as_ptr()) != DA_TRUE {
+            if Trie::delete(&mut test_trie, dict_src[i].key) != DA_TRUE {
                 panic!("Failed to delete '{:?}'", dict_src[i].key);
                 //             is_failed = TRUE;
             }

--- a/src/lib/tests/api/test_store_retrieve.rs
+++ b/src/lib/tests/api/test_store_retrieve.rs
@@ -59,7 +59,7 @@ fn test_store_retrieve() {
         let mut dict_src = get_dict_src();
         for dict_p in &dict_src {
             //     for (dict_p = dict_src; dict_p->key; dict_p++) {
-            if Trie::store(&mut test_trie, dict_p.key.as_ptr(), dict_p.data) != DA_TRUE {
+            if Trie::store(&mut test_trie, dict_p.key, dict_p.data) != DA_TRUE {
                 panic!(
                     "Failed to add key '{:?}', data {}.\n",
                     dict_p.key, dict_p.data

--- a/src/lib/tests/api/test_store_retrieve.rs
+++ b/src/lib/tests/api/test_store_retrieve.rs
@@ -73,7 +73,7 @@ fn test_store_retrieve() {
         //     is_failed = FALSE;
         for dict_p in &dict_src {
             let mut trie_data = 0;
-            if Trie::retrieve(&test_trie, dict_p.key.as_ptr(), &mut trie_data) != DA_TRUE {
+            if Trie::retrieve(&test_trie, dict_p.key, &mut trie_data) != DA_TRUE {
                 panic!("Failed to retrieve key '{:?}'.\n", dict_p.key);
             }
             assert_eq!(
@@ -126,7 +126,7 @@ fn test_store_retrieve() {
             }
 
             let mut trie_data = 0;
-            if Trie::retrieve(&test_trie, dict_p.key.as_ptr(), &mut trie_data) != DA_TRUE {
+            if Trie::retrieve(&test_trie, dict_p.key, &mut trie_data) != DA_TRUE {
                 panic!("Failed to retrieve key {:?}'.\n", dict_p.key);
                 //             is_failed = TRUE;
             }

--- a/src/lib/tests/api/test_term_state.rs
+++ b/src/lib/tests/api/test_term_state.rs
@@ -29,7 +29,7 @@
 use datrie::{
     alpha_map::AlphaChar,
     trie::{Trie, TrieState, DA_TRUE},
-    DatrieResult,
+    AlphaStr, DatrieResult,
 };
 
 use crate::utils::{en_trie_new, msg_step, TRIE_DATA_ERROR};
@@ -61,15 +61,22 @@ fn test_term_state() -> DatrieResult<()> {
 
         /* populate trie */
         msg_step("Populating trie with test set");
-        let key_ab = &['a' as AlphaChar, 'b' as AlphaChar, 0x0000];
+        let key_ab =
+            AlphaStr::from_slice_with_nul(&['a' as AlphaChar, 'b' as AlphaChar, 0x0000]).unwrap();
         assert_eq!(
-            Trie::store(&mut test_trie, key_ab.as_ptr(), 1),
+            Trie::store(&mut test_trie, key_ab, 1),
             DA_TRUE,
             "Failed to add key 'ab', data 1.\n"
         );
-        let key_abc = &['a' as AlphaChar, 'b' as AlphaChar, 'c' as AlphaChar, 0x0000];
+        let key_abc = AlphaStr::from_slice_with_nul(&[
+            'a' as AlphaChar,
+            'b' as AlphaChar,
+            'c' as AlphaChar,
+            0x0000,
+        ])
+        .unwrap();
         assert_eq!(
-            Trie::store(&mut test_trie, key_abc.as_ptr(), 2),
+            Trie::store(&mut test_trie, key_abc, 2),
             DA_TRUE,
             "Failed to add key 'abc', data 2.\n"
         );

--- a/src/lib/tests/api/test_walk.rs
+++ b/src/lib/tests/api/test_walk.rs
@@ -198,7 +198,7 @@ fn test_walk() -> DatrieResult<()> {
         for dict_p in &walk_dict {
             //     for (dict_p = walk_dict; dict_p->key; dict_p++) {
             assert_eq!(
-                Trie::store(&mut test_trie, dict_p.key.as_ptr(), dict_p.data),
+                Trie::store(&mut test_trie, dict_p.key, dict_p.data),
                 DA_TRUE,
                 "Failed to add key '{:?}', data {}.\n",
                 dict_p.key,

--- a/src/lib/tests/api/test_walk.rs
+++ b/src/lib/tests/api/test_walk.rs
@@ -44,83 +44,92 @@ use crate::utils::{DictRec, TRIE_DATA_ERROR, TRIE_DATA_UNREAD};
 //  *                              +---g-> (24) -r-> (25) -e-> (26) -s-> (27) -s-> [28]
 //  *
 //  */
-const WALK_DICT: [DictRec; 6] = [
-    DictRec {
-        key: &[
-            'p' as AlphaChar,
-            'o' as AlphaChar,
-            'o' as AlphaChar,
-            'l' as AlphaChar,
-            0x0000,
-        ],
-        data: TRIE_DATA_UNREAD,
-    },
-    DictRec {
-        key: &[
-            'p' as AlphaChar,
-            'r' as AlphaChar,
-            'i' as AlphaChar,
-            'z' as AlphaChar,
-            'e' as AlphaChar,
-            0x0000,
-        ],
-        data: TRIE_DATA_UNREAD,
-    },
-    DictRec {
-        key: &[
-            'p' as AlphaChar,
-            'r' as AlphaChar,
-            'e' as AlphaChar,
-            'v' as AlphaChar,
-            'i' as AlphaChar,
-            'e' as AlphaChar,
-            'w' as AlphaChar,
-            0x0000,
-        ],
-        data: TRIE_DATA_UNREAD,
-    },
-    DictRec {
-        key: &[
-            'p' as AlphaChar,
-            'r' as AlphaChar,
-            'e' as AlphaChar,
-            'p' as AlphaChar,
-            'a' as AlphaChar,
-            'r' as AlphaChar,
-            'e' as AlphaChar,
-            0x0000,
-        ],
-        data: TRIE_DATA_UNREAD,
-    },
-    DictRec {
-        key: &[
-            'p' as AlphaChar,
-            'r' as AlphaChar,
-            'o' as AlphaChar,
-            'd' as AlphaChar,
-            'u' as AlphaChar,
-            'c' as AlphaChar,
-            'e' as AlphaChar,
-            0x0000,
-        ],
-        data: TRIE_DATA_UNREAD,
-    },
-    DictRec {
-        key: &[
-            'p' as AlphaChar,
-            'r' as AlphaChar,
-            'o' as AlphaChar,
-            'g' as AlphaChar,
-            'r' as AlphaChar,
-            'e' as AlphaChar,
-            's' as AlphaChar,
-            's' as AlphaChar,
-            0x0000,
-        ],
-        data: TRIE_DATA_UNREAD,
-    },
-    //     {(AlphaChar *)NULL,          TRIE_DATA_ERROR},
-];
+fn get_walk_dict() -> [DictRec; 6] {
+    [
+        DictRec {
+            key: &AlphaStr::from_slice_with_nul(&[
+                'p' as AlphaChar,
+                'o' as AlphaChar,
+                'o' as AlphaChar,
+                'l' as AlphaChar,
+                0x0000,
+            ])
+            .unwrap(),
+            data: TRIE_DATA_UNREAD,
+        },
+        DictRec {
+            key: &AlphaStr::from_slice_with_nul(&[
+                'p' as AlphaChar,
+                'r' as AlphaChar,
+                'i' as AlphaChar,
+                'z' as AlphaChar,
+                'e' as AlphaChar,
+                0x0000,
+            ])
+            .unwrap(),
+
+            data: TRIE_DATA_UNREAD,
+        },
+        DictRec {
+            key: &AlphaStr::from_slice_with_nul(&[
+                'p' as AlphaChar,
+                'r' as AlphaChar,
+                'e' as AlphaChar,
+                'v' as AlphaChar,
+                'i' as AlphaChar,
+                'e' as AlphaChar,
+                'w' as AlphaChar,
+                0x0000,
+            ])
+            .unwrap(),
+            data: TRIE_DATA_UNREAD,
+        },
+        DictRec {
+            key: &AlphaStr::from_slice_with_nul(&[
+                'p' as AlphaChar,
+                'r' as AlphaChar,
+                'e' as AlphaChar,
+                'p' as AlphaChar,
+                'a' as AlphaChar,
+                'r' as AlphaChar,
+                'e' as AlphaChar,
+                0x0000,
+            ])
+            .unwrap(),
+            data: TRIE_DATA_UNREAD,
+        },
+        DictRec {
+            key: &AlphaStr::from_slice_with_nul(&[
+                'p' as AlphaChar,
+                'r' as AlphaChar,
+                'o' as AlphaChar,
+                'd' as AlphaChar,
+                'u' as AlphaChar,
+                'c' as AlphaChar,
+                'e' as AlphaChar,
+                0x0000,
+            ])
+            .unwrap(),
+            data: TRIE_DATA_UNREAD,
+        },
+        DictRec {
+            key: &AlphaStr::from_slice_with_nul(&[
+                'p' as AlphaChar,
+                'r' as AlphaChar,
+                'o' as AlphaChar,
+                'g' as AlphaChar,
+                'r' as AlphaChar,
+                'e' as AlphaChar,
+                's' as AlphaChar,
+                's' as AlphaChar,
+                0x0000,
+            ])
+            .unwrap(),
+            data: TRIE_DATA_UNREAD,
+        },
+        //     {(AlphaChar *)NULL,          TRIE_DATA_ERROR},
+    ]
+}
 
 // static Bool
 unsafe fn is_walkables_include(
@@ -161,7 +170,7 @@ const ALPHABET_SIZE: usize = 256;
 use datrie::{
     alpha_map::AlphaChar,
     trie::{Trie, TrieState, DA_TRUE},
-    DatrieResult,
+    AlphaStr, DatrieResult,
 };
 
 use crate::utils::{en_trie_new, msg_step};
@@ -185,7 +194,7 @@ fn test_walk() -> DatrieResult<()> {
         //     }
 
         /* store */
-        let walk_dict = WALK_DICT;
+        let walk_dict = get_walk_dict();
         for dict_p in &walk_dict {
             //     for (dict_p = walk_dict; dict_p->key; dict_p++) {
             assert_eq!(

--- a/src/lib/tests/api/utils.rs
+++ b/src/lib/tests/api/utils.rs
@@ -27,7 +27,7 @@
 //  *---------------------------*/
 #[derive(Debug, Clone, Copy)]
 pub struct DictRec {
-    pub key: &'static [AlphaChar],
+    pub key: &'static AlphaStr,
     pub data: TrieData,
 }
 
@@ -74,7 +74,7 @@ pub const TRIE_DATA_READ: TrieData = 2;
 use datrie::{
     alpha_map::{alpha_char_strcmp, AlphaChar, AlphaMap},
     trie::{Trie, TrieData},
-    DatrieResult,
+    AlphaStr, DatrieResult,
 };
 
 // /*---------------------*
@@ -107,11 +107,11 @@ pub fn en_trie_new() -> DatrieResult<Trie> {
 pub fn get_dict_src() -> [DictRec; 39] {
     [
         DictRec {
-            key: &['a' as AlphaChar, 0x0000],
+            key: &AlphaStr::from_slice_with_nul(&['a' as AlphaChar, 0x0000]).unwrap(),
             data: TRIE_DATA_UNREAD,
         },
         DictRec {
-            key: &[
+            key: &AlphaStr::from_slice_with_nul(&[
                 'a' as AlphaChar,
                 'b' as AlphaChar,
                 'a' as AlphaChar,
@@ -119,11 +119,12 @@ pub fn get_dict_src() -> [DictRec; 39] {
                 'u' as AlphaChar,
                 's' as AlphaChar,
                 0x0000,
-            ],
+            ])
+            .unwrap(),
             data: TRIE_DATA_UNREAD,
         },
         DictRec {
-            key: &[
+            key: &AlphaStr::from_slice_with_nul(&[
                 'a' as AlphaChar,
                 'b' as AlphaChar,
                 'a' as AlphaChar,
@@ -132,11 +133,12 @@ pub fn get_dict_src() -> [DictRec; 39] {
                 'o' as AlphaChar,
                 'n' as AlphaChar,
                 0x0000,
-            ],
+            ])
+            .unwrap(),
             data: TRIE_DATA_UNREAD,
         },
         DictRec {
-            key: &[
+            key: &AlphaStr::from_slice_with_nul(&[
                 'a' as AlphaChar,
                 'c' as AlphaChar,
                 'c' as AlphaChar,
@@ -146,11 +148,12 @@ pub fn get_dict_src() -> [DictRec; 39] {
                 'n' as AlphaChar,
                 't' as AlphaChar,
                 0x0000,
-            ],
+            ])
+            .unwrap(),
             data: TRIE_DATA_UNREAD,
         },
         DictRec {
-            key: &[
+            key: &AlphaStr::from_slice_with_nul(&[
                 'a' as AlphaChar,
                 'c' as AlphaChar,
                 'c' as AlphaChar,
@@ -160,11 +163,12 @@ pub fn get_dict_src() -> [DictRec; 39] {
                 'i' as AlphaChar,
                 't' as AlphaChar,
                 0x0000,
-            ],
+            ])
+            .unwrap(),
             data: TRIE_DATA_UNREAD,
         },
         DictRec {
-            key: &[
+            key: &AlphaStr::from_slice_with_nul(&[
                 'a' as AlphaChar,
                 'l' as AlphaChar,
                 'g' as AlphaChar,
@@ -175,11 +179,12 @@ pub fn get_dict_src() -> [DictRec; 39] {
                 'h' as AlphaChar,
                 'm' as AlphaChar,
                 0x0000,
-            ],
+            ])
+            .unwrap(),
             data: TRIE_DATA_UNREAD,
         },
         DictRec {
-            key: &[
+            key: &AlphaStr::from_slice_with_nul(&[
                 'a' as AlphaChar,
                 'm' as AlphaChar,
                 'm' as AlphaChar,
@@ -188,121 +193,155 @@ pub fn get_dict_src() -> [DictRec; 39] {
                 'i' as AlphaChar,
                 'a' as AlphaChar,
                 0x0000,
-            ],
+            ])
+            .unwrap(),
             data: TRIE_DATA_UNREAD,
         },
         DictRec {
-            key: &[
+            key: &AlphaStr::from_slice_with_nul(&[
                 'a' as AlphaChar,
                 'n' as AlphaChar,
                 'g' as AlphaChar,
                 'e' as AlphaChar,
                 'l' as AlphaChar,
                 0x0000,
-            ],
+            ])
+            .unwrap(),
             data: TRIE_DATA_UNREAD,
         },
         DictRec {
-            key: &[
+            key: &AlphaStr::from_slice_with_nul(&[
                 'a' as AlphaChar,
                 'n' as AlphaChar,
                 'g' as AlphaChar,
                 'l' as AlphaChar,
                 'e' as AlphaChar,
                 0x0000,
-            ],
+            ])
+            .unwrap(),
             data: TRIE_DATA_UNREAD,
         },
         DictRec {
-            key: &[
+            key: &AlphaStr::from_slice_with_nul(&[
                 'a' as AlphaChar,
                 'z' as AlphaChar,
                 'u' as AlphaChar,
                 'r' as AlphaChar,
                 'e' as AlphaChar,
                 0x0000,
-            ],
+            ])
+            .unwrap(),
             data: TRIE_DATA_UNREAD,
         },
         DictRec {
-            key: &['b' as AlphaChar, 'a' as AlphaChar, 't' as AlphaChar, 0x0000],
+            key: &AlphaStr::from_slice_with_nul(&[
+                'b' as AlphaChar,
+                'a' as AlphaChar,
+                't' as AlphaChar,
+                0x0000,
+            ])
+            .unwrap(),
             data: TRIE_DATA_UNREAD,
         },
         DictRec {
-            key: &['b' as AlphaChar, 'e' as AlphaChar, 't' as AlphaChar, 0x0000],
+            key: &AlphaStr::from_slice_with_nul(&[
+                'b' as AlphaChar,
+                'e' as AlphaChar,
+                't' as AlphaChar,
+                0x0000,
+            ])
+            .unwrap(),
             data: TRIE_DATA_UNREAD,
         },
         DictRec {
-            key: &[
+            key: &AlphaStr::from_slice_with_nul(&[
                 'b' as AlphaChar,
                 'e' as AlphaChar,
                 's' as AlphaChar,
                 't' as AlphaChar,
                 0x0000,
-            ],
+            ])
+            .unwrap(),
             data: TRIE_DATA_UNREAD,
         },
         DictRec {
-            key: &[
+            key: &AlphaStr::from_slice_with_nul(&[
                 'h' as AlphaChar,
                 'o' as AlphaChar,
                 'm' as AlphaChar,
                 'e' as AlphaChar,
                 0x0000,
-            ],
+            ])
+            .unwrap(),
             data: TRIE_DATA_UNREAD,
         },
         DictRec {
-            key: &[
+            key: &AlphaStr::from_slice_with_nul(&[
                 'h' as AlphaChar,
                 'o' as AlphaChar,
                 'u' as AlphaChar,
                 's' as AlphaChar,
                 'e' as AlphaChar,
                 0x0000,
-            ],
+            ])
+            .unwrap(),
             data: TRIE_DATA_UNREAD,
         },
         DictRec {
-            key: &['h' as AlphaChar, 'u' as AlphaChar, 't' as AlphaChar, 0x0000],
+            key: &AlphaStr::from_slice_with_nul(&[
+                'h' as AlphaChar,
+                'u' as AlphaChar,
+                't' as AlphaChar,
+                0x0000,
+            ])
+            .unwrap(),
             data: TRIE_DATA_UNREAD,
         },
         DictRec {
-            key: &[
+            key: &AlphaStr::from_slice_with_nul(&[
                 'k' as AlphaChar,
                 'i' as AlphaChar,
                 'n' as AlphaChar,
                 'g' as AlphaChar,
                 0x0000,
-            ],
+            ])
+            .unwrap(),
             data: TRIE_DATA_UNREAD,
         },
         DictRec {
-            key: &[
+            key: &AlphaStr::from_slice_with_nul(&[
                 'k' as AlphaChar,
                 'i' as AlphaChar,
                 't' as AlphaChar,
                 'e' as AlphaChar,
                 0x0000,
-            ],
+            ])
+            .unwrap(),
             data: TRIE_DATA_UNREAD,
         },
         DictRec {
-            key: &[
+            key: &AlphaStr::from_slice_with_nul(&[
                 'n' as AlphaChar,
                 'a' as AlphaChar,
                 'm' as AlphaChar,
                 'e' as AlphaChar,
                 0x0000,
-            ],
+            ])
+            .unwrap(),
             data: TRIE_DATA_UNREAD,
         },
         DictRec {
-            key: &['n' as AlphaChar, 'e' as AlphaChar, 't' as AlphaChar, 0x0000],
+            key: &AlphaStr::from_slice_with_nul(&[
+                'n' as AlphaChar,
+                'e' as AlphaChar,
+                't' as AlphaChar,
+                0x0000,
+            ])
+            .unwrap(),
             data: TRIE_DATA_UNREAD,
         },
         DictRec {
-            key: &[
+            key: &AlphaStr::from_slice_with_nul(&[
                 'n' as AlphaChar,
                 'e' as AlphaChar,
                 't' as AlphaChar,
@@ -311,15 +350,22 @@ pub fn get_dict_src() -> [DictRec; 39] {
                 'r' as AlphaChar,
                 'k' as AlphaChar,
                 0x0000,
-            ],
+            ])
+            .unwrap(),
             data: TRIE_DATA_UNREAD,
         },
         DictRec {
-            key: &['n' as AlphaChar, 'u' as AlphaChar, 't' as AlphaChar, 0x0000],
+            key: &AlphaStr::from_slice_with_nul(&[
+                'n' as AlphaChar,
+                'u' as AlphaChar,
+                't' as AlphaChar,
+                0x0000,
+            ])
+            .unwrap(),
             data: TRIE_DATA_UNREAD,
         },
         DictRec {
-            key: &[
+            key: &AlphaStr::from_slice_with_nul(&[
                 'n' as AlphaChar,
                 'u' as AlphaChar,
                 't' as AlphaChar,
@@ -329,11 +375,12 @@ pub fn get_dict_src() -> [DictRec; 39] {
                 'l' as AlphaChar,
                 'l' as AlphaChar,
                 0x0000,
-            ],
+            ])
+            .unwrap(),
             data: TRIE_DATA_UNREAD,
         },
         DictRec {
-            key: &[
+            key: &AlphaStr::from_slice_with_nul(&[
                 'q' as AlphaChar,
                 'u' as AlphaChar,
                 'a' as AlphaChar,
@@ -342,11 +389,12 @@ pub fn get_dict_src() -> [DictRec; 39] {
                 't' as AlphaChar,
                 'y' as AlphaChar,
                 0x0000,
-            ],
+            ])
+            .unwrap(),
             data: TRIE_DATA_UNREAD,
         },
         DictRec {
-            key: &[
+            key: &AlphaStr::from_slice_with_nul(&[
                 'q' as AlphaChar,
                 'u' as AlphaChar,
                 'a' as AlphaChar,
@@ -355,11 +403,12 @@ pub fn get_dict_src() -> [DictRec; 39] {
                 'u' as AlphaChar,
                 'm' as AlphaChar,
                 0x0000,
-            ],
+            ])
+            .unwrap(),
             data: TRIE_DATA_UNREAD,
         },
         DictRec {
-            key: &[
+            key: &AlphaStr::from_slice_with_nul(&[
                 'q' as AlphaChar,
                 'u' as AlphaChar,
                 'a' as AlphaChar,
@@ -369,11 +418,12 @@ pub fn get_dict_src() -> [DictRec; 39] {
                 't' as AlphaChar,
                 'y' as AlphaChar,
                 0x0000,
-            ],
+            ])
+            .unwrap(),
             data: TRIE_DATA_UNREAD,
         },
         DictRec {
-            key: &[
+            key: &AlphaStr::from_slice_with_nul(&[
                 'q' as AlphaChar,
                 'u' as AlphaChar,
                 'a' as AlphaChar,
@@ -381,113 +431,141 @@ pub fn get_dict_src() -> [DictRec; 39] {
                 't' as AlphaChar,
                 'z' as AlphaChar,
                 0x0000,
-            ],
+            ])
+            .unwrap(),
             data: TRIE_DATA_UNREAD,
         },
         DictRec {
-            key: &[
+            key: &AlphaStr::from_slice_with_nul(&[
                 'q' as AlphaChar,
                 'u' as AlphaChar,
                 'i' as AlphaChar,
                 'c' as AlphaChar,
                 'k' as AlphaChar,
                 0x0000,
-            ],
+            ])
+            .unwrap(),
             data: TRIE_DATA_UNREAD,
         },
         DictRec {
-            key: &[
+            key: &AlphaStr::from_slice_with_nul(&[
                 'q' as AlphaChar,
                 'u' as AlphaChar,
                 'i' as AlphaChar,
                 'z' as AlphaChar,
                 0x0000,
-            ],
+            ])
+            .unwrap(),
             data: TRIE_DATA_UNREAD,
         },
         DictRec {
-            key: &['r' as AlphaChar, 'u' as AlphaChar, 'n' as AlphaChar, 0x0000],
+            key: &AlphaStr::from_slice_with_nul(&[
+                'r' as AlphaChar,
+                'u' as AlphaChar,
+                'n' as AlphaChar,
+                0x0000,
+            ])
+            .unwrap(),
             data: TRIE_DATA_UNREAD,
         },
         DictRec {
-            key: &[
+            key: &AlphaStr::from_slice_with_nul(&[
                 't' as AlphaChar,
                 'a' as AlphaChar,
                 'p' as AlphaChar,
                 'e' as AlphaChar,
                 0x0000,
-            ],
+            ])
+            .unwrap(),
             data: TRIE_DATA_UNREAD,
         },
         DictRec {
-            key: &[
+            key: &AlphaStr::from_slice_with_nul(&[
                 't' as AlphaChar,
                 'e' as AlphaChar,
                 's' as AlphaChar,
                 't' as AlphaChar,
                 0x0000,
-            ],
+            ])
+            .unwrap(),
             data: TRIE_DATA_UNREAD,
         },
         DictRec {
-            key: &[
+            key: &AlphaStr::from_slice_with_nul(&[
                 'w' as AlphaChar,
                 'h' as AlphaChar,
                 'a' as AlphaChar,
                 't' as AlphaChar,
                 0x0000,
-            ],
+            ])
+            .unwrap(),
             data: TRIE_DATA_UNREAD,
         },
         DictRec {
-            key: &[
+            key: &AlphaStr::from_slice_with_nul(&[
                 'w' as AlphaChar,
                 'h' as AlphaChar,
                 'e' as AlphaChar,
                 'n' as AlphaChar,
                 0x0000,
-            ],
+            ])
+            .unwrap(),
             data: TRIE_DATA_UNREAD,
         },
         DictRec {
-            key: &[
+            key: &AlphaStr::from_slice_with_nul(&[
                 'w' as AlphaChar,
                 'h' as AlphaChar,
                 'e' as AlphaChar,
                 'r' as AlphaChar,
                 'e' as AlphaChar,
                 0x0000,
-            ],
+            ])
+            .unwrap(),
             data: TRIE_DATA_UNREAD,
         },
         DictRec {
-            key: &[
+            key: &AlphaStr::from_slice_with_nul(&[
                 'w' as AlphaChar,
                 'h' as AlphaChar,
                 'i' as AlphaChar,
                 'c' as AlphaChar,
                 'h' as AlphaChar,
                 0x0000,
-            ],
+            ])
+            .unwrap(),
             data: TRIE_DATA_UNREAD,
         },
         DictRec {
-            key: &['w' as AlphaChar, 'h' as AlphaChar, 'o' as AlphaChar, 0x0000],
+            key: &AlphaStr::from_slice_with_nul(&[
+                'w' as AlphaChar,
+                'h' as AlphaChar,
+                'o' as AlphaChar,
+                0x0000,
+            ])
+            .unwrap(),
             data: TRIE_DATA_UNREAD,
         },
         DictRec {
-            key: &['w' as AlphaChar, 'h' as AlphaChar, 'y' as AlphaChar, 0x0000],
+            key: &AlphaStr::from_slice_with_nul(&[
+                'w' as AlphaChar,
+                'h' as AlphaChar,
+                'y' as AlphaChar,
+                0x0000,
+            ])
+            .unwrap(),
             data: TRIE_DATA_UNREAD,
         },
         DictRec {
-            key: &[
+            key: &AlphaStr::from_slice_with_nul(&[
                 'z' as AlphaChar,
                 'e' as AlphaChar,
                 'b' as AlphaChar,
                 'r' as AlphaChar,
                 'a' as AlphaChar,
                 0x0000,
-            ],
+            ])
+            .unwrap(),
             data: TRIE_DATA_UNREAD,
         },
         //     {(AlphaChar *)NULL,          TRIE_DATA_ERROR},

--- a/src/lib/trie.rs
+++ b/src/lib/trie.rs
@@ -195,12 +195,12 @@ impl Trie {
         DA_TRUE
     }
 
-    pub unsafe fn store(&mut self, key: *const AlphaChar, data: TrieData) -> Bool {
-        self.store_conditionally(key, data, DA_TRUE)
+    pub unsafe fn store(&mut self, key: &AlphaStr, data: TrieData) -> Bool {
+        self.store_conditionally(key.as_ptr(), data, DA_TRUE)
     }
 
-    pub unsafe fn store_if_absent(&mut self, key: *const AlphaChar, data: TrieData) -> Bool {
-        self.store_conditionally(key, data, DA_FALSE)
+    pub unsafe fn store_if_absent(&mut self, key: &AlphaStr, data: TrieData) -> Bool {
+        self.store_conditionally(key.as_ptr(), data, DA_FALSE)
     }
     unsafe fn store_conditionally(
         &mut self,

--- a/src/lib/trie.rs
+++ b/src/lib/trie.rs
@@ -7,7 +7,7 @@ use std::path::Path;
 use std::{fs, io};
 
 use crate::fileutils::{CFile, ReadExt};
-use crate::{alpha_map::*, darray::*, tail::*};
+use crate::{alpha_map::*, darray::*, tail::*, AlphaStr};
 use crate::{trie_string::*, DatrieError, DatrieResult, ErrorKind};
 use ::libc;
 
@@ -153,43 +153,39 @@ impl Trie {
     pub fn is_dirty(&self) -> Bool {
         self.is_dirty
     }
-    pub unsafe fn retrieve(&self, key: *const AlphaChar, o_data: *mut TrieData) -> Bool {
+    pub unsafe fn retrieve(&self, key: &AlphaStr, o_data: *mut TrieData) -> Bool {
         let mut s = self.da.get_root();
-        let mut p: *const AlphaChar = key;
+        let key_slice = key.to_slice_with_nul();
+        let mut p = key_slice;
+
         while self.da.get_base(s) >= 0 as libc::c_int {
-            let tc: TrieIndex = match self.alpha_map.char_to_trie(*p) {
-                Some(tc) => tc,
-                None => return DA_FALSE,
+            let Some(tc) = self.alpha_map.char_to_trie(p[0]) else {
+                return DA_FALSE;
             };
 
             if self.da.walk(&mut s, tc as TrieChar) as u64 == 0 {
                 return DA_FALSE;
             }
-
-            if unsafe { 0 as libc::c_uint == *p } {
+            if p[0] == 0 {
                 break;
             }
-            p = unsafe { p.offset(1) };
+            p = &p[1..];
         }
         s = -self.da.get_base(s);
         let mut suffix_idx: libc::c_short = 0;
         loop {
-            let tc_0: TrieIndex = match self.alpha_map.char_to_trie(*p) {
-                Some(tc) => tc,
-                None => return DA_FALSE,
+            let Some(tc_0) = self.alpha_map.char_to_trie(p[0]) else {
+                return DA_FALSE;
             };
-            // let tc_0: TrieIndex = unsafe { alpha_map_char_to_trie(self.alpha_map.as_ref(), *p) };
 
             if unsafe { self.tail.walk_char(s, &mut suffix_idx, tc_0 as TrieChar) } as u64 == 0 {
                 return DA_FALSE;
             }
-            // if p.is_null() {
-            //     break;
-            // }
-            if unsafe { 0 as libc::c_uint == *p } {
+
+            if p[0] == 0 {
                 break;
             }
-            p = unsafe { p.offset(1) };
+            p = &p[1..];
         }
         if !o_data.is_null() {
             unsafe {

--- a/src/lib/trie.rs
+++ b/src/lib/trie.rs
@@ -346,41 +346,40 @@ impl Trie {
 }
 
 impl Trie {
-    pub fn delete(&mut self, key: *const AlphaChar) -> Bool {
+    pub fn delete(&mut self, key: &AlphaStr) -> Bool {
         // let mut s: TrieIndex = 0;
         // let mut t: TrieIndex = 0;
         // let mut suffix_idx: libc::c_short = 0;
         // let mut p: *const AlphaChar = 0 as *const AlphaChar;
         let mut s = (*self.da).get_root();
-        let mut p = key;
+        let key_slice = key.to_slice_with_nul();
+        let mut p = key_slice;
         while (*self.da).get_base(s) >= 0 as libc::c_int {
-            let tc: TrieIndex = match unsafe { self.alpha_map.char_to_trie(*p) } {
-                Some(tc) => tc,
-                None => return DA_FALSE,
+            let Some(tc) = self.alpha_map.char_to_trie(p[0]) else {
+                return DA_FALSE;
             };
             if unsafe { self.da.walk(&mut s, tc as TrieChar) } as u64 == 0 {
                 return DA_FALSE;
             }
-            if unsafe { 0 as libc::c_int as libc::c_uint == *p } {
+            if p[0] == 0 {
                 break;
             }
-            p = unsafe { p.offset(1) };
+            p = &p[1..];
         }
         let t = -(*self.da).get_base(s);
         // suffix_idx = 0 as libc::c_int as libc::c_short;
         let mut suffix_idx: libc::c_short = 0;
         loop {
-            let tc_0: TrieIndex = match unsafe { self.alpha_map.char_to_trie(*p) } {
-                Some(tc) => tc,
-                None => return DA_FALSE,
+            let Some(tc_0) = self.alpha_map.char_to_trie(p[0]) else {
+                return DA_FALSE;
             };
             if unsafe { self.tail.walk_char(t, &mut suffix_idx, tc_0 as TrieChar) as u64 == 0 } {
                 return DA_FALSE;
             }
-            if unsafe { 0 as libc::c_int as libc::c_uint == *p } {
+            if p[0] == 0 {
                 break;
             }
-            p = unsafe { p.offset(1) };
+            p = &p[1..];
         }
         unsafe {
             self.tail.delete(t);

--- a/src/lib/trie/tests.rs
+++ b/src/lib/trie/tests.rs
@@ -1,4 +1,5 @@
 use crate::trie::AlphaChar;
+use crate::AlphaStr;
 use crate::{trie::Trie, DatrieResult};
 
 use crate::alpha_map::AlphaMap;
@@ -18,7 +19,11 @@ fn serialize_to_slice_works() -> DatrieResult<()> {
     alpha_map.add_range(0x00, 0xff)?;
     let mut trie = Trie::new(&alpha_map)?;
     unsafe {
-        Trie::store(&mut trie, ['a' as AlphaChar, 0x0000].as_ptr(), 2);
+        Trie::store(
+            &mut trie,
+            AlphaStr::from_slice_with_nul(&['a' as AlphaChar, 0x0000]).unwrap(),
+            2,
+        );
     }
     let size = trie.get_serialized_size();
     let mut serialized_data = Vec::with_capacity(size);


### PR DESCRIPTION
- **feat: add AlphaStr**
- **refactor: use AlphaStr in Trie::retrieve**
- **refactor: use AlphaStr in Trie::store and store_if_absent**
- **refactor: use AlphaStr in Trie::delete**

## Summary by Sourcery

Add the AlphaStr struct to manage null-terminated strings of AlphaChar and refactor Trie methods to utilize AlphaStr for improved safety and readability.

New Features:
- Introduce the AlphaStr struct to handle strings of AlphaChar with a null terminator.

Enhancements:
- Refactor the Trie methods (retrieve, store, store_if_absent, delete) to use AlphaStr instead of raw pointers to AlphaChar.